### PR TITLE
Add bucket-list to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Here are some of my personal projects on GitHub:
 *   [ahcd](https://github.com/freddiefujiwara/ahcd) - A converter for Apple Health Care Data.
 *   [dtdt](https://github.com/freddiefujiwara/dtdt) - A test generator from decision trees to decision tables.
 *   [list-of-stuff](https://github.com/freddiefujiwara/list-of-stuff) - A simple project using Vue.js.
-*   [bucket-list](https://github.com/freddiefujiwara/bucket-list/) - A bucket list app to collect life goals as tiles you can browse.
+*   [bucket-list](https://github.com/freddiefujiwara/bucket-list/) - My bucket list with life goals displayed as tiles.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Here are some of my personal projects on GitHub:
 *   [ahcd](https://github.com/freddiefujiwara/ahcd) - A converter for Apple Health Care Data.
 *   [dtdt](https://github.com/freddiefujiwara/dtdt) - A test generator from decision trees to decision tables.
 *   [list-of-stuff](https://github.com/freddiefujiwara/list-of-stuff) - A simple project using Vue.js.
-*   [bucket-list](https://github.com/freddiefujiwara/bucket-list/)
+*   [bucket-list](https://github.com/freddiefujiwara/bucket-list/) - A bucket list app to collect life goals as tiles you can browse.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Here are some of my personal projects on GitHub:
 *   [ahcd](https://github.com/freddiefujiwara/ahcd) - A converter for Apple Health Care Data.
 *   [dtdt](https://github.com/freddiefujiwara/dtdt) - A test generator from decision trees to decision tables.
 *   [list-of-stuff](https://github.com/freddiefujiwara/list-of-stuff) - A simple project using Vue.js.
+*   [bucket-list](https://github.com/freddiefujiwara/bucket-list/)
 
 ---
 


### PR DESCRIPTION
### Motivation

* Keep the personal projects list in `README.md` up to date by adding a missing repository link.
* Make it easier for visitors to discover the `bucket-list` project from the profile page.

### Description

* Updated `README.md` to add the `*   [bucket-list](https://github.com/freddiefujiwara/bucket-list/)` entry in the Projects section.
* The change is a single-line insertion and the file was committed to the repository.

### Testing

* No automated tests were run because this is a documentation-only change.
* No test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694fc2376930832f951e774638ddeedd)