### PR TITLE
Add blog link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Here are some of my personal projects on GitHub:
 ## Links
 
 *   **Website:** [freddiefujiwara.com](https://freddiefujiwara.com/)
+*   **Blog:** [freddiefujiwara.com/blog](https://freddiefujiwara.com/blog/)
 *   **GitHub:** [@freddiefujiwara](https://github.com/freddiefujiwara)
 *   **X:** [@freddiefujiwara](https://x.com/freddiefujiwara)
 *   **LinkedIn:** [freddiefujiwara](https://linkedin.com/in/freddiefujiwara)


### PR DESCRIPTION
### Motivation
- Surface the personal blog by adding a direct link to the Links section of the README.

### Description
- Inserted a new `**Blog:**` link line into `README.md` under the Links section pointing to `https://freddiefujiwara.com/blog/`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697eb2065cf4832f88cbe6033edf5055)