### PR TITLE
Add OGP and Twitter Card meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fumikazu “Freddie” Fujiwara's Portfolio</title>
+  <meta property="og:title" content="Fumikazu “Freddie” Fujiwara's Portfolio">
+  <meta property="og:description" content="A professional Software Test Manager and a hobbyist Software Developer.">
+  <meta property="og:url" content="https://freddiefujiwara.github.io">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="style.css">
   <link rel="icon"
   href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23000'/%3E%3Ctext x='32' y='42' font-size='34' text-anchor='middle' fill='white' font-family='system-ui'%3EF%3C/text%3E%3C/svg%3E">

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <title>Fumikazu “Freddie” Fujiwara's Portfolio</title>
   <meta property="og:title" content="Fumikazu “Freddie” Fujiwara's Portfolio">
   <meta property="og:description" content="A professional Software Test Manager and a hobbyist Software Developer.">
-  <meta property="og:url" content="https://freddiefujiwara.github.io">
+  <meta property="og:url" content="https://freddiefujiwara.com">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="style.css">

--- a/script.test.js
+++ b/script.test.js
@@ -83,12 +83,15 @@ describe('README Fetch and Render', () => {
   it('should have OGP and Twitter meta tags in index.html', () => {
     const ogTitle = document.querySelector('meta[property="og:title"]');
     const ogDescription = document.querySelector('meta[property="og:description"]');
+    const ogUrl = document.querySelector('meta[property="og:url"]');
     const twitterCard = document.querySelector('meta[name="twitter:card"]');
 
     expect(ogTitle).not.toBeNull();
     expect(ogTitle.getAttribute('content')).toBe("Fumikazu “Freddie” Fujiwara's Portfolio");
     expect(ogDescription).not.toBeNull();
     expect(ogDescription.getAttribute('content')).toBe("A professional Software Test Manager and a hobbyist Software Developer.");
+    expect(ogUrl).not.toBeNull();
+    expect(ogUrl.getAttribute('content')).toBe("https://freddiefujiwara.com");
     expect(twitterCard).not.toBeNull();
     expect(twitterCard.getAttribute('content')).toBe('summary');
   });

--- a/script.test.js
+++ b/script.test.js
@@ -79,4 +79,17 @@ describe('README Fetch and Render', () => {
     const currentYear = new Date().getFullYear().toString();
     expect(yearSpan.textContent).toBe(currentYear);
   });
+
+  it('should have OGP and Twitter meta tags in index.html', () => {
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    const ogDescription = document.querySelector('meta[property="og:description"]');
+    const twitterCard = document.querySelector('meta[name="twitter:card"]');
+
+    expect(ogTitle).not.toBeNull();
+    expect(ogTitle.getAttribute('content')).toBe("Fumikazu “Freddie” Fujiwara's Portfolio");
+    expect(ogDescription).not.toBeNull();
+    expect(ogDescription.getAttribute('content')).toBe("A professional Software Test Manager and a hobbyist Software Developer.");
+    expect(twitterCard).not.toBeNull();
+    expect(twitterCard.getAttribute('content')).toBe('summary');
+  });
 });


### PR DESCRIPTION
I have added OGP (Open Graph Protocol) and Twitter Card support to the portfolio page. 

Key changes:
1. **Static Meta Tags:** Added `<meta>` tags directly to `public/index.html`. This ensures that social media crawlers (like X/Twitter, Facebook, Slack, Discord) can read the metadata even if they don't execute JavaScript.
2. **Dynamic Maintenance:** Although the tags are static, I used the same title and description already present on the page to maintain consistency.
3. **Minimalist Approach:** As requested, I avoided adding any new image files. I configured the Twitter Card as a `summary` type, which works well without a large preview image.
4. **Testing:** Updated `script.test.js` to include a test case that verifies the presence and correctness of these meta tags in the HTML.

This implementation provides a professional link preview when the portfolio is shared on social media or messaging platforms.

---
*PR created automatically by Jules for task [17370111461549129502](https://jules.google.com/task/17370111461549129502) started by @freddiefujiwara*