### PR TITLE
Add OGP and Twitter image metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,12 @@
   <meta property="og:description" content="A professional Software Test Manager and a hobbyist Software Developer.">
   <meta property="og:url" content="https://freddiefujiwara.com">
   <meta property="og:type" content="website">
+  <meta property="og:image" content="https://github.com/freddiefujiwara.png">
+  <meta property="og:image:width" content="400">
+  <meta property="og:image:height" content="400">
+  <meta property="og:image:alt" content="Fumikazu “Freddie” Fujiwara">
   <meta name="twitter:card" content="summary">
+  <meta name="twitter:image" content="https://github.com/freddiefujiwara.png">
   <link rel="stylesheet" href="style.css">
   <link rel="icon"
   href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23000'/%3E%3Ctext x='32' y='42' font-size='34' text-anchor='middle' fill='white' font-family='system-ui'%3EF%3C/text%3E%3C/svg%3E">

--- a/script.test.js
+++ b/script.test.js
@@ -84,7 +84,12 @@ describe('README Fetch and Render', () => {
     const ogTitle = document.querySelector('meta[property="og:title"]');
     const ogDescription = document.querySelector('meta[property="og:description"]');
     const ogUrl = document.querySelector('meta[property="og:url"]');
+    const ogImage = document.querySelector('meta[property="og:image"]');
+    const ogImageWidth = document.querySelector('meta[property="og:image:width"]');
+    const ogImageHeight = document.querySelector('meta[property="og:image:height"]');
+    const ogImageAlt = document.querySelector('meta[property="og:image:alt"]');
     const twitterCard = document.querySelector('meta[name="twitter:card"]');
+    const twitterImage = document.querySelector('meta[name="twitter:image"]');
 
     expect(ogTitle).not.toBeNull();
     expect(ogTitle.getAttribute('content')).toBe("Fumikazu “Freddie” Fujiwara's Portfolio");
@@ -92,7 +97,17 @@ describe('README Fetch and Render', () => {
     expect(ogDescription.getAttribute('content')).toBe("A professional Software Test Manager and a hobbyist Software Developer.");
     expect(ogUrl).not.toBeNull();
     expect(ogUrl.getAttribute('content')).toBe("https://freddiefujiwara.com");
+    expect(ogImage).not.toBeNull();
+    expect(ogImage.getAttribute('content')).toBe("https://github.com/freddiefujiwara.png");
+    expect(ogImageWidth).not.toBeNull();
+    expect(ogImageWidth.getAttribute('content')).toBe("400");
+    expect(ogImageHeight).not.toBeNull();
+    expect(ogImageHeight.getAttribute('content')).toBe("400");
+    expect(ogImageAlt).not.toBeNull();
+    expect(ogImageAlt.getAttribute('content')).toBe("Fumikazu “Freddie” Fujiwara");
     expect(twitterCard).not.toBeNull();
     expect(twitterCard.getAttribute('content')).toBe('summary');
+    expect(twitterImage).not.toBeNull();
+    expect(twitterImage.getAttribute('content')).toBe("https://github.com/freddiefujiwara.png");
   });
 });


### PR DESCRIPTION
Added OGP and Twitter image metadata to `public/index.html` and updated `script.test.js` to include assertions for the new tags. Used the GitHub avatar URL as a minimalist solution that avoids adding new assets to the repository and ensures compatibility across social media platforms.

---
*PR created automatically by Jules for task [5695490058926661979](https://jules.google.com/task/5695490058926661979) started by @freddiefujiwara*