### PR TITLE
Add ogp-png, md2img, and html2ppt to README Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Here are some of my personal projects on GitHub:
 *   [dtdt](https://github.com/freddiefujiwara/dtdt) - A test generator from decision trees to decision tables.
 *   [list-of-stuff](https://github.com/freddiefujiwara/list-of-stuff) - A simple project using Vue.js.
 *   [bucket-list](https://github.com/freddiefujiwara/bucket-list/) - My bucket list with life goals displayed as tiles.
+*   [ogp-png](https://github.com/freddiefujiwara/ogp-png) - Generate OGP images in PNG format.
+*   [md2img](https://github.com/freddiefujiwara/md2img) - Convert Markdown files into images.
+*   [html2ppt](https://github.com/freddiefujiwara/html2ppt) - Convert HTML slides into PowerPoint files.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Add three recently created repositories to the Projects list so the README reflects current work.

### Description
- Inserted links for `ogp-png`, `md2img`, and `html2ppt` into the Projects section of `README.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698589ea0eb4832f94466ecfd34c491f)