### PR TITLE
Match look & feel with ha.ze.gs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <title>Fumikazu “Freddie” Fujiwara's Portfolio</title>
   <meta property="og:title" content="Fumikazu “Freddie” Fujiwara's Portfolio">
   <meta property="og:description" content="A professional Software Test Manager and a hobbyist Software Developer.">
@@ -19,16 +22,18 @@
   href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23000'/%3E%3Ctext x='32' y='42' font-size='34' text-anchor='middle' fill='white' font-family='system-ui'%3EF%3C/text%3E%3C/svg%3E">
 </head>
 <body>
-  <header>
-    <h1>Fumikazu “Freddie” Fujiwara</h1>
-    <p>A professional Software Test Manager and a hobbyist Software Developer.</p>
-  </header>
-  <main>
-    <div id="content"></div>
-  </main>
-  <footer>
-    <p>&copy; <span id="copyright-year">2024</span> Fumikazu “Freddie” Fujiwara</p>
-  </footer>
+  <div class="layout">
+    <header class="header">
+      <h1>Fumikazu “Freddie” Fujiwara</h1>
+      <p>A professional Software Test Manager and a hobbyist Software Developer.</p>
+    </header>
+    <main>
+      <div id="content"></div>
+    </main>
+    <footer>
+      <p>&copy; <span id="copyright-year">2024</span> Fumikazu “Freddie” Fujiwara</p>
+    </footer>
+  </div>
 
   <!-- CDN for marked.js -->
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -1,89 +1,162 @@
+:root {
+  font-family: Inter, "Hiragino Kaku Gothic ProN", "Hiragino Sans", sans-serif;
+  line-height: 1.5;
+
+  --bg: #0b1120;
+  --text: #e5e7eb;
+  --muted: #94a3b8;
+  --surface: #111827;
+  --surface-elevated: #1f2937;
+  --border: #334155;
+  --link: #93c5fd;
+  --link-active: #ffffff;
+  --error: #fca5a5;
+  --primary: #3b82f6;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f8fafc;
+    --text: #1f2937;
+    --muted: #64748b;
+    --surface: #ffffff;
+    --surface-elevated: #f8fafc;
+    --border: #e2e8f0;
+    --link: #1d4ed8;
+    --link-active: #0f172a;
+    --error: #b91c1c;
+    --primary: #2563eb;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
 body {
-    font-family: 'Helvetica Neue', Arial, sans-serif;
-    line-height: 1.8;
-    margin: 0 auto;
-    max-width: 800px;
-    padding: 2rem;
-    background: #121212;
-    color: #e0e0e0;
+  min-height: 100%;
 }
 
-header {
-    text-align: center;
-    margin-bottom: 4rem;
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  transition: background 0.2s, color 0.2s;
+  line-height: 1.6;
 }
 
-header h1 {
-    font-size: 2rem;
-    margin: 0;
-    font-weight: 300;
+.layout {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 16px;
 }
 
-header p {
-    margin: 0.5rem 0 0;
-    font-size: 1.1rem;
-    color: #a0a0a0;
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 40px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 24px;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-weight: 700;
+  color: var(--link);
+}
+
+.header p {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--muted);
 }
 
 main {
-    padding: 0;
+  padding: 0;
 }
 
 #content {
-    padding: 0;
+  padding: 0;
 }
 
-#content h1, #content h2, #content h3 {
-    border-bottom: 1px solid #333;
-    padding-bottom: 0.5rem;
-    margin-top: 2.5rem;
-    font-weight: 400;
+#content h1,
+#content h2,
+#content h3 {
+  color: var(--text);
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
 }
 
 #content h1 {
-    font-size: 1.8rem;
+  font-size: 1.8rem;
+  border-bottom: 2px solid var(--border);
+  padding-bottom: 0.5rem;
 }
 
 #content h2 {
-    font-size: 1.5rem;
+  font-size: 1.5rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.3rem;
 }
 
 #content h3 {
-    font-size: 1.2rem;
-}
-
-#content ul {
-    padding-left: 20px;
-    list-style-type: circle;
-}
-
-#content li {
-    margin-bottom: 0.5rem;
-}
-
-#content a {
-    color: #66b3ff;
-    text-decoration: none;
-}
-
-#content a:hover {
-    text-decoration: underline;
+  font-size: 1.2rem;
 }
 
 #content p {
-    margin: 1rem 0;
+  margin: 1rem 0;
+}
+
+#content ul {
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+#content li {
+  margin-bottom: 0.5rem;
+}
+
+#content a {
+  color: var(--link);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+#content a:hover {
+  color: var(--link-active);
+  text-decoration: underline;
 }
 
 #content hr {
-    border: 0;
-    border-top: 1px solid #333;
-    margin: 3rem 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2rem 0;
+}
+
+#content img {
+  max-width: 100%;
+  height: auto;
 }
 
 footer {
-    text-align: center;
-    padding: 2rem 0;
-    margin-top: 4rem;
-    font-size: 0.9rem;
-    color: #777;
+  text-align: center;
+  padding: 40px 0;
+  margin-top: 40px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .layout {
+    padding: 12px;
+  }
+
+  .header h1 {
+    font-size: 1.75rem;
+  }
 }


### PR DESCRIPTION
The portfolio website's look and feel has been updated to exactly match the provided reference (https://github.com/freddiefujiwara/ha.ze.gs). 

Key changes:
- Added the 'Inter' font via Google Fonts.
- Updated the HTML structure to include a `.layout` container (max-width 1200px) and updated classes for the header.
- Completely redesigned `public/style.css` using the color scheme and styling principles from the target repository.
- Added support for light mode via `@media (prefers-color-scheme: light)`.
- Verified the changes visually using a Playwright screenshot and functionally via the existing test suite.
- Ensured no external dependencies were added to the final submission.

---
*PR created automatically by Jules for task [7210605805761726310](https://jules.google.com/task/7210605805761726310) started by @freddiefujiwara*